### PR TITLE
Created new rooms reservation feature

### DIFF
--- a/Bot/Admin/set_captain.py
+++ b/Bot/Admin/set_captain.py
@@ -1,0 +1,88 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+from typing import List, cast
+from utils.db import db
+from Admin.admin import Admin
+
+
+class SetCaptain(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @app_commands.command(name="set_captain", description="(Admin) Set the captain of an existing team.")
+    @app_commands.describe(
+        team_nick="Nickname of the team",
+        member="The new captain",
+    )
+    async def set_captain(
+        self,
+        interaction: discord.Interaction,
+        team_nick: str,
+        member: discord.Member,
+    ):
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command can only be used in a server.", ephemeral=True
+            )
+            return
+
+        admin_cog = cast(Admin, self.bot.get_cog("Admin"))
+        if (
+            not isinstance(interaction.user, discord.Member)
+            or admin_cog is None
+            or not await admin_cog.is_admin(interaction.user)
+        ):
+            await interaction.response.send_message(
+                "You do not have permission to use this command.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+
+        try:
+            teams = await db.execute(
+                "SELECT team_id FROM teams WHERE team_nick = $1 AND archived = FALSE",
+                team_nick,
+            )
+            if not teams:
+                await interaction.followup.send(
+                    f"Active team `{team_nick}` not found."
+                )
+                return
+
+            team_id = teams[0]["team_id"]
+
+            # Ensure the new captain is in the players table
+            await db.execute(
+                "INSERT INTO players (player_discord_id) VALUES ($1) ON CONFLICT DO NOTHING",
+                member.id,
+            )
+
+            await db.execute(
+                "UPDATE teams SET captain_discord_id = $1 WHERE team_id = $2",
+                member.id,
+                team_id,
+            )
+            await interaction.followup.send(
+                f"{member.mention} is now the captain of **{team_nick}**."
+            )
+        except Exception as e:
+            await interaction.followup.send(f"Error: {e}")
+
+    @set_captain.autocomplete("team_nick")
+    async def team_nick_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ) -> List[app_commands.Choice[str]]:
+        records = await db.execute(
+            "SELECT team_nick FROM teams WHERE team_nick ILIKE $1 AND archived = FALSE LIMIT 25",
+            f"%{current}%",
+        )
+        return [
+            app_commands.Choice(name=r["team_nick"], value=r["team_nick"])
+            for r in records
+        ]
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(SetCaptain(bot))

--- a/Bot/Rooms/reservations.py
+++ b/Bot/Rooms/reservations.py
@@ -1,0 +1,170 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+from typing import List
+from utils.db import db
+
+
+class Reservations(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    async def _get_captain_team(self, user_id: int):
+        """Return the active team record for which this user is captain, or None."""
+        teams = await db.execute(
+            "SELECT team_id, team_nick FROM teams WHERE captain_discord_id = $1 AND archived = FALSE",
+            user_id,
+        )
+        return teams[0] if teams else None
+
+    @app_commands.command(name="reserve", description="Reserve a room slot for your team (captains only).")
+    @app_commands.describe(slot_id="Slot ID to reserve")
+    async def reserve(self, interaction: discord.Interaction, slot_id: int):
+        await interaction.response.defer(ephemeral=True)
+
+        team = await self._get_captain_team(interaction.user.id)
+        if team is None:
+            await interaction.followup.send(
+                "You are not a captain of any active team.", ephemeral=True
+            )
+            return
+
+        try:
+            slot = await db.execute(
+                """
+                SELECT rs.slot_id, r.room_name, rs.start_time, rs.end_time
+                FROM room_slots rs
+                JOIN rooms r ON r.room_id = rs.room_id
+                WHERE rs.slot_id = $1
+                """,
+                slot_id,
+            )
+            if not slot:
+                await interaction.followup.send(f"Slot `#{slot_id}` not found.")
+                return
+
+            slot = slot[0]
+
+            existing = await db.execute(
+                "SELECT reservation_id FROM room_reservations WHERE slot_id = $1", slot_id
+            )
+            if existing:
+                await interaction.followup.send(
+                    f"Slot `#{slot_id}` is already reserved."
+                )
+                return
+
+            await db.execute(
+                "INSERT INTO room_reservations (slot_id, team_id) VALUES ($1, $2)",
+                slot_id,
+                team["team_id"],
+            )
+            start = slot["start_time"].strftime("%Y-%m-%d %H:%M")
+            end = slot["end_time"].strftime("%H:%M")
+            await interaction.followup.send(
+                f"Reserved `{slot['room_name']}` slot `#{slot_id}` ({start} — {end}) for **{team['team_nick']}**."
+            )
+        except Exception as e:
+            await interaction.followup.send(f"Error: {e}")
+
+    @app_commands.command(name="cancel_reservation", description="Cancel your team's room reservation (captains only).")
+    @app_commands.describe(slot_id="Slot ID to cancel")
+    async def cancel_reservation(self, interaction: discord.Interaction, slot_id: int):
+        await interaction.response.defer(ephemeral=True)
+
+        team = await self._get_captain_team(interaction.user.id)
+        if team is None:
+            await interaction.followup.send(
+                "You are not a captain of any active team.", ephemeral=True
+            )
+            return
+
+        try:
+            reservation = await db.execute(
+                "SELECT reservation_id, team_id FROM room_reservations WHERE slot_id = $1",
+                slot_id,
+            )
+            if not reservation:
+                await interaction.followup.send(f"No reservation found for slot `#{slot_id}`.")
+                return
+
+            if reservation[0]["team_id"] != team["team_id"]:
+                await interaction.followup.send(
+                    "You can only cancel reservations made by your own team."
+                )
+                return
+
+            await db.execute(
+                "DELETE FROM room_reservations WHERE slot_id = $1", slot_id
+            )
+            await interaction.followup.send(
+                f"Reservation for slot `#{slot_id}` cancelled."
+            )
+        except Exception as e:
+            await interaction.followup.send(f"Error: {e}")
+
+    @app_commands.command(name="list_rooms", description="View all available (unreserved) room slots.")
+    @app_commands.describe(room_name="Filter by room name (optional)")
+    async def list_rooms(self, interaction: discord.Interaction, room_name: str = ""):
+        await interaction.response.defer()
+
+        try:
+            if room_name:
+                records = await db.execute(
+                    """
+                    SELECT rs.slot_id, r.room_name, rs.start_time, rs.end_time
+                    FROM room_slots rs
+                    JOIN rooms r ON r.room_id = rs.room_id
+                    LEFT JOIN room_reservations rr ON rr.slot_id = rs.slot_id
+                    WHERE rr.slot_id IS NULL AND r.room_name ILIKE $1
+                    ORDER BY rs.start_time
+                    """,
+                    f"%{room_name}%",
+                )
+            else:
+                records = await db.execute(
+                    """
+                    SELECT rs.slot_id, r.room_name, rs.start_time, rs.end_time
+                    FROM room_slots rs
+                    JOIN rooms r ON r.room_id = rs.room_id
+                    LEFT JOIN room_reservations rr ON rr.slot_id = rs.slot_id
+                    WHERE rr.slot_id IS NULL
+                    ORDER BY rs.start_time
+                    """
+                )
+
+            if not records:
+                msg = "No available slots"
+                msg += f" for `{room_name}`." if room_name else "."
+                await interaction.followup.send(msg)
+                return
+
+            lines = ["**Available Room Slots**", "```"]
+            lines.append(f"{'#':<6} {'Room':<20} {'Start':<18} {'End':<10}")
+            lines.append("-" * 56)
+            for r in records:
+                start = r["start_time"].strftime("%Y-%m-%d %H:%M")
+                end = r["end_time"].strftime("%H:%M")
+                lines.append(f"{r['slot_id']:<6} {r['room_name']:<20} {start:<18} {end:<10}")
+            lines.append("```")
+
+            await interaction.followup.send("\n".join(lines))
+        except Exception as e:
+            await interaction.followup.send(f"Error: {e}")
+
+    @list_rooms.autocomplete("room_name")
+    async def room_name_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ) -> List[app_commands.Choice[str]]:
+        records = await db.execute(
+            "SELECT room_name FROM rooms WHERE room_name ILIKE $1 LIMIT 25",
+            f"%{current}%",
+        )
+        return [
+            app_commands.Choice(name=r["room_name"], value=r["room_name"])
+            for r in records
+        ]
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(Reservations(bot))

--- a/Bot/Rooms/rooms.py
+++ b/Bot/Rooms/rooms.py
@@ -1,0 +1,151 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+from typing import List, cast
+from utils.db import db
+from Admin.admin import Admin
+
+
+class Rooms(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    async def _is_admin(self, interaction: discord.Interaction) -> bool:
+        admin_cog = cast(Admin, self.bot.get_cog("Admin"))
+        return (
+            isinstance(interaction.user, discord.Member)
+            and admin_cog is not None
+            and await admin_cog.is_admin(interaction.user)
+        )
+
+    room = app_commands.Group(name="room", description="Room management commands")
+
+    @room.command(name="add_room", description="(Admin) Add a reservable room.")
+    @app_commands.describe(
+        name="Room name",
+        description="Optional description of the room",
+    )
+    async def add_room(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+        description: str = "",
+    ):
+        if not await self._is_admin(interaction):
+            await interaction.response.send_message(
+                "You do not have permission to use this command.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        try:
+            existing = await db.execute(
+                "SELECT room_id FROM rooms WHERE room_name = $1", name
+            )
+            if existing:
+                await interaction.followup.send(f"Room `{name}` already exists.")
+                return
+            await db.execute(
+                "INSERT INTO rooms (room_name, description) VALUES ($1, $2)",
+                name,
+                description or None,
+            )
+            await interaction.followup.send(f"Room `{name}` added.")
+        except Exception as e:
+            await interaction.followup.send(f"Error: {e}")
+
+    @room.command(name="add_slot", description="(Admin) Add an available time slot to a room.")
+    @app_commands.describe(
+        room_name="Name of the room",
+        start_time="Start time (YYYY-MM-DD HH:MM)",
+        end_time="End time (YYYY-MM-DD HH:MM)",
+    )
+    async def add_slot(
+        self,
+        interaction: discord.Interaction,
+        room_name: str,
+        start_time: str,
+        end_time: str,
+    ):
+        if not await self._is_admin(interaction):
+            await interaction.response.send_message(
+                "You do not have permission to use this command.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        try:
+            from datetime import datetime
+            start_dt = datetime.fromisoformat(start_time)
+            end_dt = datetime.fromisoformat(end_time)
+        except ValueError:
+            await interaction.followup.send(
+                "Invalid time format. Use `YYYY-MM-DD HH:MM`."
+            )
+            return
+
+        if end_dt <= start_dt:
+            await interaction.followup.send("End time must be after start time.")
+            return
+
+        try:
+            room = await db.execute(
+                "SELECT room_id FROM rooms WHERE room_name = $1", room_name
+            )
+            if not room:
+                await interaction.followup.send(f"Room `{room_name}` not found.")
+                return
+
+            room_id = room[0]["room_id"]
+            result = await db.execute(
+                "INSERT INTO room_slots (room_id, start_time, end_time) VALUES ($1, $2, $3) RETURNING slot_id",
+                room_id,
+                start_dt,
+                end_dt,
+            )
+            slot_id = result[0]["slot_id"]
+            await interaction.followup.send(
+                f"Slot `#{slot_id}` added to `{room_name}`: {start_time} — {end_time}"
+            )
+        except Exception as e:
+            await interaction.followup.send(f"Error: {e}")
+
+    @room.command(name="remove_slot", description="(Admin) Remove a time slot (and its reservation if any).")
+    @app_commands.describe(slot_id="Slot ID to remove")
+    async def remove_slot(self, interaction: discord.Interaction, slot_id: int):
+        if not await self._is_admin(interaction):
+            await interaction.response.send_message(
+                "You do not have permission to use this command.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        try:
+            slot = await db.execute(
+                "SELECT slot_id FROM room_slots WHERE slot_id = $1", slot_id
+            )
+            if not slot:
+                await interaction.followup.send(f"Slot `#{slot_id}` not found.")
+                return
+            # Cascades to room_reservations automatically
+            await db.execute("DELETE FROM room_slots WHERE slot_id = $1", slot_id)
+            await interaction.followup.send(f"Slot `#{slot_id}` removed.")
+        except Exception as e:
+            await interaction.followup.send(f"Error: {e}")
+
+    @add_slot.autocomplete("room_name")
+    async def room_name_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ) -> List[app_commands.Choice[str]]:
+        records = await db.execute(
+            "SELECT room_name FROM rooms WHERE room_name ILIKE $1 LIMIT 25",
+            f"%{current}%",
+        )
+        return [
+            app_commands.Choice(name=r["room_name"], value=r["room_name"])
+            for r in records
+        ]
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(Rooms(bot))

--- a/Bot/main.py
+++ b/Bot/main.py
@@ -24,9 +24,12 @@ class MyClient(commands.Bot):
         await self.load_extension("Teams.archive_team")
         await self.load_extension("Teams.list_teams")
         await self.load_extension("Admin.admin")
+        await self.load_extension("Admin.set_captain")
         await self.load_extension("Dues.set-dues")
         await self.load_extension("Dues.generate")
         await self.load_extension("Webscrape.webscrape")
+        await self.load_extension("Rooms.rooms")
+        await self.load_extension("Rooms.reservations")
 
         # Then sync to the guild
         guild = discord.Object(id=1481037920499400704)

--- a/Documentation/rooms.md
+++ b/Documentation/rooms.md
@@ -89,3 +89,138 @@ Provides autocomplete suggestions for active team nicknames.
 
 **Returns:**
 - `List[app_commands.Choice[str]]`: Up to 25 matching team nicknames
+
+---
+
+## rooms.py
+
+Provides admin commands for managing rooms and available time slots.
+
+#### Overview
+
+This module lets admins define what rooms exist and when they are available for booking. Rooms are a simple registry; slots are time windows attached to a room that captains can later reserve. Deleting a slot automatically removes any reservation on it.
+
+#### Dependencies
+
+**External:**
+- `discord.py` - Discord bot API wrapper
+- `asyncpg` - Async PostgreSQL driver (via utils.db)
+
+**Internal:**
+- `utils.db` - Database connection manager
+- `Admin` cog - Permission verification
+
+#### Classes
+
+###### `Rooms(commands.Cog)`
+
+Discord cog for room and slot management.
+
+**Attributes:**
+- `bot` (commands.Bot): Reference to the Discord bot instance
+
+**Methods:**
+- `_is_admin()` - Internal admin permission check
+- `add_room()` - Command to register a new room
+- `add_slot()` - Command to add an available time slot
+- `remove_slot()` - Command to remove a time slot
+- `room_name_autocomplete()` - Autocomplete handler for room names
+
+#### Commands
+
+All commands are grouped under `/room` and require admin privileges.
+
+###### `/room add_room`
+
+Registers a new room that can have time slots assigned to it.
+
+**Parameters:**
+- `name` (str): Unique room name
+- `description` (str, optional): Description of the room
+
+**Behavior:**
+1. Checks the room doesn't already exist
+2. Inserts a new row into the rooms table
+
+**Example Usage:**
+```
+/room add_room name:Lab A description:Computer lab on floor 2
+```
+
+###### `/room add_slot`
+
+Adds an available time slot to a room.
+
+**Parameters:**
+- `room_name` (str): Name of the room (autocompleted)
+- `start_time` (str): Start time in `YYYY-MM-DD HH:MM` format
+- `end_time` (str): End time in `YYYY-MM-DD HH:MM` format
+
+**Behavior:**
+1. Parses and validates the time strings
+2. Ensures end time is after start time
+3. Looks up the room by name
+4. Inserts a new slot and returns its ID
+
+**Error Handling:**
+- Returns error if time strings are not valid ISO format
+- Returns error if end time is not after start time
+- Returns error if the room does not exist
+
+**Example Usage:**
+```
+/room add_slot room_name:Lab A start_time:2026-04-20 10:00 end_time:2026-04-20 12:00
+```
+
+###### `/room remove_slot`
+
+Removes a time slot. If the slot has a reservation, the reservation is deleted automatically via cascade.
+
+**Parameters:**
+- `slot_id` (int): ID of the slot to remove
+
+**Behavior:**
+1. Verifies the slot exists
+2. Deletes the slot (cascades to room_reservations)
+
+**Example Usage:**
+```
+/room remove_slot slot_id:42
+```
+
+#### Functions
+
+###### `_is_admin(self, interaction) -> bool`
+
+Checks if the interaction user has an admin role.
+
+**Parameters:**
+- `interaction` (discord.Interaction): Discord interaction object
+
+**Returns:**
+- `bool`: True if user is an admin, False otherwise
+
+###### `add_room(self, interaction, name, description)`
+
+**Database Operations:**
+- SELECT: Checks for existing room with same name
+- INSERT: Adds row to rooms table
+
+###### `add_slot(self, interaction, room_name, start_time, end_time)`
+
+**Database Operations:**
+- SELECT: Looks up room_id by room_name
+- INSERT: Adds row to room_slots, returns slot_id
+
+###### `remove_slot(self, interaction, slot_id)`
+
+**Database Operations:**
+- SELECT: Verifies slot exists
+- DELETE: Removes slot (cascades to room_reservations)
+
+###### `room_name_autocomplete(self, interaction, current)`
+
+Provides autocomplete suggestions for room names on the `add_slot` command.
+
+**Returns:**
+- `List[app_commands.Choice[str]]`: Up to 25 matching room names

--- a/Documentation/rooms.md
+++ b/Documentation/rooms.md
@@ -1,0 +1,91 @@
+# Rooms & Reservations
+
+## set_captain.py
+
+Provides an admin command to update the captain of an existing active team.
+
+#### Overview
+
+This module allows admins to reassign team captains without going through the full team creation wizard. It updates `captain_discord_id` in the teams table and ensures the new captain exists in the players table.
+
+#### Dependencies
+
+**External:**
+- `discord.py` - Discord bot API wrapper
+- `asyncpg` - Async PostgreSQL driver (via utils.db)
+
+**Internal:**
+- `utils.db` - Database connection manager
+- `Admin` cog - Permission verification
+
+#### Classes
+
+###### `SetCaptain(commands.Cog)`
+
+Discord cog for updating team captains.
+
+**Attributes:**
+- `bot` (commands.Bot): Reference to the Discord bot instance
+
+**Methods:**
+- `set_captain()` - Command to update a team's captain
+- `team_nick_autocomplete()` - Autocomplete handler for team selection
+
+#### Commands
+
+###### `/set_captain`
+
+Updates the captain of an existing active team.
+
+**Parameters:**
+- `team_nick` (str): Nickname of the team to update
+- `member` (discord.Member): The new captain
+
+**Permissions:**
+- Requires admin privileges (checked via Admin cog)
+
+**Behavior:**
+1. Verifies user has admin permissions
+2. Looks up the active team by nickname
+3. Upserts the new captain into the players table
+4. Updates `captain_discord_id` on the team
+
+**Error Handling:**
+- Returns error if command used outside a server
+- Returns error if user lacks admin permissions
+- Returns error if no active team matches the given nickname
+
+**Example Usage:**
+```
+/set_captain team_nick:Dragons member:@JohnDoe
+```
+
+#### Functions
+
+###### `set_captain(self, interaction, team_nick, member)`
+
+**Parameters:**
+- `self`: Reference to SetCaptain cog instance
+- `interaction` (discord.Interaction): Discord interaction object
+- `team_nick` (str): Nickname of the team
+- `member` (discord.Member): New captain
+
+**Returns:**
+- None (sends response via interaction followup)
+
+**Database Operations:**
+- SELECT: Finds active team by team_nick
+- INSERT: Upserts member into players table (ON CONFLICT DO NOTHING)
+- UPDATE: Sets captain_discord_id on the team
+
+###### `team_nick_autocomplete(self, interaction, current)`
+
+Provides autocomplete suggestions for active team nicknames.
+
+**Parameters:**
+- `self`: Reference to SetCaptain cog instance
+- `interaction` (discord.Interaction): Discord interaction object
+- `current` (str): Current text typed by user
+
+**Returns:**
+- `List[app_commands.Choice[str]]`: Up to 25 matching team nicknames

--- a/Documentation/rooms.md
+++ b/Documentation/rooms.md
@@ -224,3 +224,172 @@ Provides autocomplete suggestions for room names on the `add_slot` command.
 
 **Returns:**
 - `List[app_commands.Choice[str]]`: Up to 25 matching room names
+
+---
+
+## reservations.py
+
+Provides commands for team captains to reserve and cancel room slots, and a public command to view available slots.
+
+#### Overview
+
+This module is the main interface for room booking. Captains can reserve open slots for their team and cancel existing reservations. Anyone can view what slots are still available. Double-booking is prevented both by a `UNIQUE` constraint in the database and by an explicit check before inserting.
+
+#### Dependencies
+
+**External:**
+- `discord.py` - Discord bot API wrapper
+- `asyncpg` - Async PostgreSQL driver (via utils.db)
+
+**Internal:**
+- `utils.db` - Database connection manager
+
+#### Classes
+
+###### `Reservations(commands.Cog)`
+
+Discord cog for room reservations.
+
+**Attributes:**
+- `bot` (commands.Bot): Reference to the Discord bot instance
+
+**Methods:**
+- `_get_captain_team()` - Internal helper to find the caller's team
+- `reserve()` - Command to book a slot
+- `cancel_reservation()` - Command to cancel a booking
+- `list_rooms()` - Command to view available slots
+- `room_name_autocomplete()` - Autocomplete handler for room names
+
+#### Commands
+
+###### `/reserve`
+
+Reserves a room slot for the caller's team. Caller must be a captain of an active team.
+
+**Parameters:**
+- `slot_id` (int): ID of the slot to reserve
+
+**Behavior:**
+1. Looks up an active team where the caller is captain
+2. Verifies the slot exists
+3. Checks the slot has no existing reservation
+4. Creates the reservation
+
+**Error Handling:**
+- Returns error if caller is not a captain of any active team
+- Returns error if slot ID does not exist
+- Returns error if slot is already reserved
+
+**Example Usage:**
+```
+/reserve slot_id:42
+```
+
+###### `/cancel_reservation`
+
+Cancels a room reservation. Caller must be the captain of the team that made the reservation.
+
+**Parameters:**
+- `slot_id` (int): ID of the slot to cancel
+
+**Behavior:**
+1. Looks up the caller's active team
+2. Finds the reservation for the given slot
+3. Verifies the reservation belongs to the caller's team
+4. Deletes the reservation
+
+**Error Handling:**
+- Returns error if caller is not a captain
+- Returns error if no reservation exists for the slot
+- Returns error if the reservation belongs to a different team
+
+**Example Usage:**
+```
+/cancel_reservation slot_id:42
+```
+
+###### `/list_rooms`
+
+Displays all unreserved time slots. Open to everyone.
+
+**Parameters:**
+- `room_name` (str, optional): Filter results to a specific room (autocompleted)
+
+**Behavior:**
+1. Queries for slots with no matching reservation
+2. Optionally filters by room name (case-insensitive)
+3. Displays results in a formatted table showing slot ID, room, start, and end times
+
+**Response Format:**
+```
+Available Room Slots
+#      Room                 Start              End
+--------------------------------------------------------
+1      Lab A                2026-04-20 10:00   12:00
+```
+
+**Example Usage:**
+```
+/list_rooms
+/list_rooms room_name:Lab A
+```
+
+#### Functions
+
+###### `_get_captain_team(self, user_id) -> dict | None`
+
+Looks up the active team for which the given user is captain.
+
+**Parameters:**
+- `user_id` (int): Discord user ID
+
+**Returns:**
+- `dict` with `team_id` and `team_nick`, or `None` if not a captain
+
+**Database Operations:**
+- SELECT: Queries teams where captain_discord_id matches and archived is FALSE
+
+###### `reserve(self, interaction, slot_id)`
+
+**Database Operations:**
+- SELECT (via `_get_captain_team`): Finds caller's team
+- SELECT: Fetches slot and room info by slot_id
+- SELECT: Checks for existing reservation on slot
+- INSERT: Creates reservation in room_reservations
+
+###### `cancel_reservation(self, interaction, slot_id)`
+
+**Database Operations:**
+- SELECT (via `_get_captain_team`): Finds caller's team
+- SELECT: Finds reservation by slot_id
+- DELETE: Removes the reservation
+
+###### `list_rooms(self, interaction, room_name)`
+
+**Database Operations:**
+- SELECT: LEFT JOIN between room_slots and room_reservations, filtered to unbooked slots, optionally filtered by room name
+
+###### `room_name_autocomplete(self, interaction, current)`
+
+Provides autocomplete suggestions for room names on the `list_rooms` command.
+
+**Returns:**
+- `List[app_commands.Choice[str]]`: Up to 25 matching room names
+
+#### Database Schema Requirements
+
+**rooms table:**
+- `room_id` (serial) - Primary key
+- `room_name` (varchar, unique) - Room identifier
+- `description` (varchar, nullable) - Optional description
+
+**room_slots table:**
+- `slot_id` (serial) - Primary key
+- `room_id` (int) - Foreign key to rooms (CASCADE on delete)
+- `start_time` (timestamptz) - Slot start
+- `end_time` (timestamptz) - Slot end, must be after start_time
+
+**room_reservations table:**
+- `reservation_id` (serial) - Primary key
+- `slot_id` (int, unique) - Foreign key to room_slots (CASCADE on delete); UNIQUE enforces no double-booking
+- `team_id` (int) - Foreign key to teams (CASCADE on delete)

--- a/Tests/Admin/test_set_captain.py
+++ b/Tests/Admin/test_set_captain.py
@@ -1,0 +1,62 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import discord
+
+from Admin.set_captain import SetCaptain
+
+
+def _pass_admin_guard(cog, interaction):
+    user = MagicMock(spec=discord.Member)
+    user.id = 1
+    interaction.user = user
+    admin_mock = MagicMock()
+    admin_mock.is_admin = AsyncMock(return_value=True)
+    cog.bot.get_cog = MagicMock(return_value=admin_mock)
+
+
+@pytest.fixture
+def cog():
+    return SetCaptain(MagicMock())
+
+
+def make_interaction(*, has_guild=True, is_admin=True):
+    interaction = MagicMock()
+    interaction.response = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+
+    interaction.guild = MagicMock(spec=discord.Guild) if has_guild else None
+
+    admin_cog = MagicMock()
+    admin_cog.is_admin = AsyncMock(return_value=is_admin)
+    interaction.client = MagicMock()
+    interaction.client.get_cog = MagicMock(return_value=admin_cog if has_guild else None)
+
+    return interaction
+
+
+def make_member(user_id=42):
+    member = MagicMock(spec=discord.Member)
+    member.id = user_id
+    member.mention = f"<@{user_id}>"
+    return member
+
+
+# --- guard tests ---
+
+@pytest.mark.asyncio
+async def test_set_captain_no_guild(cog):
+    interaction = make_interaction(has_guild=False)
+    await cog.set_captain.callback(cog, interaction, team_nick="Dragons", member=make_member())
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.call_args[0][0]
+    assert "server" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_set_captain_no_permission(cog):
+    interaction = make_interaction(is_admin=False)
+    await cog.set_captain.callback(cog, interaction, team_nick="Dragons", member=make_member())
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.call_args[0][0]
+    assert "permission" in msg.lower()

--- a/Tests/Admin/test_set_captain.py
+++ b/Tests/Admin/test_set_captain.py
@@ -60,3 +60,61 @@ async def test_set_captain_no_permission(cog):
     interaction.response.send_message.assert_awaited_once()
     msg = interaction.response.send_message.call_args[0][0]
     assert "permission" in msg.lower()
+
+
+# --- logic tests ---
+
+@pytest.mark.asyncio
+async def test_set_captain_team_not_found(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    with patch("Admin.set_captain.db.execute", new=AsyncMock(return_value=[])):
+        await cog.set_captain.callback(cog, interaction, team_nick="Ghost", member=make_member())
+    msg = interaction.followup.send.call_args[0][0]
+    assert "not found" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_set_captain_success(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    member = make_member(user_id=99)
+    with patch("Admin.set_captain.db.execute", new=AsyncMock(side_effect=[
+        [{"team_id": 5}],
+        None,
+        None,
+    ])):
+        await cog.set_captain.callback(cog, interaction, team_nick="Dragons", member=member)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "captain" in msg.lower()
+    assert "dragons" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_set_captain_db_error(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    with patch("Admin.set_captain.db.execute", new=AsyncMock(side_effect=Exception("DB down"))):
+        await cog.set_captain.callback(cog, interaction, team_nick="Dragons", member=make_member())
+    msg = interaction.followup.send.call_args[0][0]
+    assert "error" in msg.lower()
+
+
+# --- autocomplete ---
+
+@pytest.mark.asyncio
+async def test_team_nick_autocomplete_returns_choices(cog):
+    interaction = MagicMock()
+    fake_records = [{"team_nick": "Dragons"}, {"team_nick": "Drakes"}]
+    with patch("Admin.set_captain.db.execute", new=AsyncMock(return_value=fake_records)):
+        choices = await cog.team_nick_autocomplete(interaction, "dr")
+    assert len(choices) == 2
+    assert choices[0].name == "Dragons"
+
+
+@pytest.mark.asyncio
+async def test_team_nick_autocomplete_empty(cog):
+    interaction = MagicMock()
+    with patch("Admin.set_captain.db.execute", new=AsyncMock(return_value=[])):
+        choices = await cog.team_nick_autocomplete(interaction, "zzz")
+    assert choices == []

--- a/Tests/Rooms/test_reservations.py
+++ b/Tests/Rooms/test_reservations.py
@@ -89,3 +89,60 @@ async def test_reserve_db_error(cog):
             await cog.reserve.callback(cog, interaction, slot_id=1)
     msg = interaction.followup.send.call_args[0][0]
     assert "error" in msg.lower()
+
+
+# --- cancel_reservation ---
+
+@pytest.mark.asyncio
+async def test_cancel_not_captain(cog):
+    interaction = make_interaction()
+    with patch.object(cog, "_get_captain_team", new=AsyncMock(return_value=None)):
+        await cog.cancel_reservation.callback(cog, interaction, slot_id=1)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "captain" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_no_reservation(cog):
+    interaction = make_interaction()
+    fake_team = {"team_id": 10, "team_nick": "Dragons"}
+    with patch.object(cog, "_get_captain_team", new=AsyncMock(return_value=fake_team)):
+        with patch("Rooms.reservations.db.execute", new=AsyncMock(return_value=[])):
+            await cog.cancel_reservation.callback(cog, interaction, slot_id=1)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "no reservation" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_wrong_team(cog):
+    interaction = make_interaction()
+    fake_team = {"team_id": 10, "team_nick": "Dragons"}
+    fake_reservation = [{"reservation_id": 3, "team_id": 99}]
+    with patch.object(cog, "_get_captain_team", new=AsyncMock(return_value=fake_team)):
+        with patch("Rooms.reservations.db.execute", new=AsyncMock(return_value=fake_reservation)):
+            await cog.cancel_reservation.callback(cog, interaction, slot_id=1)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "own team" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_success(cog):
+    interaction = make_interaction()
+    fake_team = {"team_id": 10, "team_nick": "Dragons"}
+    fake_reservation = [{"reservation_id": 3, "team_id": 10}]
+    with patch.object(cog, "_get_captain_team", new=AsyncMock(return_value=fake_team)):
+        with patch("Rooms.reservations.db.execute", new=AsyncMock(side_effect=[fake_reservation, None])):
+            await cog.cancel_reservation.callback(cog, interaction, slot_id=1)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "cancelled" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_db_error(cog):
+    interaction = make_interaction()
+    fake_team = {"team_id": 10, "team_nick": "Dragons"}
+    with patch.object(cog, "_get_captain_team", new=AsyncMock(return_value=fake_team)):
+        with patch("Rooms.reservations.db.execute", new=AsyncMock(side_effect=Exception("DB down"))):
+            await cog.cancel_reservation.callback(cog, interaction, slot_id=1)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "error" in msg.lower()

--- a/Tests/Rooms/test_reservations.py
+++ b/Tests/Rooms/test_reservations.py
@@ -1,0 +1,91 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import discord
+
+from Rooms.reservations import Reservations
+
+
+@pytest.fixture
+def cog():
+    return Reservations(MagicMock())
+
+
+def make_interaction():
+    interaction = MagicMock()
+    interaction.response = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    interaction.user = MagicMock()
+    interaction.user.id = 100
+    return interaction
+
+
+def make_fake_slot():
+    start = MagicMock()
+    start.strftime = MagicMock(return_value="2026-04-20 10:00")
+    end = MagicMock()
+    end.strftime = MagicMock(return_value="12:00")
+    return {"slot_id": 1, "room_name": "Lab A", "start_time": start, "end_time": end}
+
+
+# --- reserve ---
+
+@pytest.mark.asyncio
+async def test_reserve_not_captain(cog):
+    interaction = make_interaction()
+    with patch.object(cog, "_get_captain_team", new=AsyncMock(return_value=None)):
+        await cog.reserve.callback(cog, interaction, slot_id=1)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "captain" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_reserve_slot_not_found(cog):
+    interaction = make_interaction()
+    fake_team = {"team_id": 10, "team_nick": "Dragons"}
+    with patch.object(cog, "_get_captain_team", new=AsyncMock(return_value=fake_team)):
+        with patch("Rooms.reservations.db.execute", new=AsyncMock(return_value=[])):
+            await cog.reserve.callback(cog, interaction, slot_id=99)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "not found" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_reserve_already_reserved(cog):
+    interaction = make_interaction()
+    fake_team = {"team_id": 10, "team_nick": "Dragons"}
+    with patch.object(cog, "_get_captain_team", new=AsyncMock(return_value=fake_team)):
+        with patch("Rooms.reservations.db.execute", new=AsyncMock(side_effect=[
+            [make_fake_slot()],
+            [{"reservation_id": 5}],
+        ])):
+            await cog.reserve.callback(cog, interaction, slot_id=1)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "already reserved" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_reserve_success(cog):
+    interaction = make_interaction()
+    fake_team = {"team_id": 10, "team_nick": "Dragons"}
+    with patch.object(cog, "_get_captain_team", new=AsyncMock(return_value=fake_team)):
+        with patch("Rooms.reservations.db.execute", new=AsyncMock(side_effect=[
+            [make_fake_slot()],
+            [],
+            None,
+        ])):
+            await cog.reserve.callback(cog, interaction, slot_id=1)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "reserved" in msg.lower()
+    assert "dragons" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_reserve_db_error(cog):
+    interaction = make_interaction()
+    fake_team = {"team_id": 10, "team_nick": "Dragons"}
+    with patch.object(cog, "_get_captain_team", new=AsyncMock(return_value=fake_team)):
+        with patch("Rooms.reservations.db.execute", new=AsyncMock(side_effect=Exception("DB down"))):
+            await cog.reserve.callback(cog, interaction, slot_id=1)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "error" in msg.lower()

--- a/Tests/Rooms/test_reservations.py
+++ b/Tests/Rooms/test_reservations.py
@@ -146,3 +146,62 @@ async def test_cancel_db_error(cog):
             await cog.cancel_reservation.callback(cog, interaction, slot_id=1)
     msg = interaction.followup.send.call_args[0][0]
     assert "error" in msg.lower()
+
+
+# --- list_rooms ---
+
+@pytest.mark.asyncio
+async def test_list_rooms_no_slots(cog):
+    interaction = make_interaction()
+    with patch("Rooms.reservations.db.execute", new=AsyncMock(return_value=[])):
+        await cog.list_rooms.callback(cog, interaction, room_name="")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "no available slots" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_list_rooms_no_slots_filtered(cog):
+    interaction = make_interaction()
+    with patch("Rooms.reservations.db.execute", new=AsyncMock(return_value=[])):
+        await cog.list_rooms.callback(cog, interaction, room_name="Lab A")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "lab a" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_list_rooms_with_slots(cog):
+    interaction = make_interaction()
+    with patch("Rooms.reservations.db.execute", new=AsyncMock(return_value=[make_fake_slot()])):
+        await cog.list_rooms.callback(cog, interaction, room_name="")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "available room slots" in msg.lower()
+    assert "lab a" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_list_rooms_db_error(cog):
+    interaction = make_interaction()
+    with patch("Rooms.reservations.db.execute", new=AsyncMock(side_effect=Exception("DB down"))):
+        await cog.list_rooms.callback(cog, interaction, room_name="")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "error" in msg.lower()
+
+
+# --- autocomplete ---
+
+@pytest.mark.asyncio
+async def test_list_rooms_autocomplete_returns_choices(cog):
+    interaction = MagicMock()
+    fake_records = [{"room_name": "Lab A"}, {"room_name": "Lab B"}]
+    with patch("Rooms.reservations.db.execute", new=AsyncMock(return_value=fake_records)):
+        choices = await cog.room_name_autocomplete(interaction, "lab")
+    assert len(choices) == 2
+    assert choices[0].name == "Lab A"
+
+
+@pytest.mark.asyncio
+async def test_list_rooms_autocomplete_empty(cog):
+    interaction = MagicMock()
+    with patch("Rooms.reservations.db.execute", new=AsyncMock(return_value=[])):
+        choices = await cog.room_name_autocomplete(interaction, "zzz")
+    assert choices == []

--- a/Tests/Rooms/test_rooms.py
+++ b/Tests/Rooms/test_rooms.py
@@ -61,3 +61,35 @@ async def test_remove_slot_no_permission(cog):
     interaction.response.send_message.assert_awaited_once()
     msg = interaction.response.send_message.call_args[0][0]
     assert "permission" in msg.lower()
+
+
+# --- add_room ---
+
+@pytest.mark.asyncio
+async def test_add_room_already_exists(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    with patch("Rooms.rooms.db.execute", new=AsyncMock(return_value=[{"room_id": 1}])):
+        await cog.add_room.callback(cog, interaction, name="Lab A", description="")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "already exists" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_add_room_success(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    with patch("Rooms.rooms.db.execute", new=AsyncMock(side_effect=[[], None])):
+        await cog.add_room.callback(cog, interaction, name="Lab A", description="A room")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "added" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_add_room_db_error(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    with patch("Rooms.rooms.db.execute", new=AsyncMock(side_effect=Exception("DB down"))):
+        await cog.add_room.callback(cog, interaction, name="Lab A", description="")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "error" in msg.lower()

--- a/Tests/Rooms/test_rooms.py
+++ b/Tests/Rooms/test_rooms.py
@@ -1,0 +1,63 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import discord
+
+from Rooms.rooms import Rooms
+
+
+def _pass_admin_guard(cog, interaction):
+    user = MagicMock(spec=discord.Member)
+    user.id = 1
+    interaction.user = user
+    admin_mock = MagicMock()
+    admin_mock.is_admin = AsyncMock(return_value=True)
+    cog.bot.get_cog = MagicMock(return_value=admin_mock)
+
+
+@pytest.fixture
+def cog():
+    return Rooms(MagicMock())
+
+
+def make_interaction(*, is_admin=True):
+    interaction = MagicMock()
+    interaction.response = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    interaction.user = MagicMock(spec=discord.Member)
+
+    admin_cog = MagicMock()
+    admin_cog.is_admin = AsyncMock(return_value=is_admin)
+    return interaction
+
+
+# --- guard tests ---
+
+@pytest.mark.asyncio
+async def test_add_room_no_permission(cog):
+    interaction = make_interaction(is_admin=False)
+    cog.bot.get_cog = MagicMock(return_value=MagicMock(is_admin=AsyncMock(return_value=False)))
+    await cog.add_room.callback(cog, interaction, name="Lab A", description="")
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.call_args[0][0]
+    assert "permission" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_add_slot_no_permission(cog):
+    interaction = make_interaction(is_admin=False)
+    cog.bot.get_cog = MagicMock(return_value=MagicMock(is_admin=AsyncMock(return_value=False)))
+    await cog.add_slot.callback(cog, interaction, room_name="Lab A", start_time="2026-04-20 10:00", end_time="2026-04-20 12:00")
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.call_args[0][0]
+    assert "permission" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_remove_slot_no_permission(cog):
+    interaction = make_interaction(is_admin=False)
+    cog.bot.get_cog = MagicMock(return_value=MagicMock(is_admin=AsyncMock(return_value=False)))
+    await cog.remove_slot.callback(cog, interaction, slot_id=1)
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.call_args[0][0]
+    assert "permission" in msg.lower()

--- a/Tests/Rooms/test_rooms.py
+++ b/Tests/Rooms/test_rooms.py
@@ -93,3 +93,57 @@ async def test_add_room_db_error(cog):
         await cog.add_room.callback(cog, interaction, name="Lab A", description="")
     msg = interaction.followup.send.call_args[0][0]
     assert "error" in msg.lower()
+
+
+# --- add_slot ---
+
+@pytest.mark.asyncio
+async def test_add_slot_invalid_time_format(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    await cog.add_slot.callback(cog, interaction, room_name="Lab A", start_time="not-a-date", end_time="also-not")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "invalid" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_add_slot_end_before_start(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    await cog.add_slot.callback(cog, interaction, room_name="Lab A", start_time="2026-04-20 12:00", end_time="2026-04-20 10:00")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "after" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_add_slot_room_not_found(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    with patch("Rooms.rooms.db.execute", new=AsyncMock(return_value=[])):
+        await cog.add_slot.callback(cog, interaction, room_name="Ghost Room", start_time="2026-04-20 10:00", end_time="2026-04-20 12:00")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "not found" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_add_slot_success(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    with patch("Rooms.rooms.db.execute", new=AsyncMock(side_effect=[
+        [{"room_id": 1}],
+        [{"slot_id": 42}],
+    ])):
+        await cog.add_slot.callback(cog, interaction, room_name="Lab A", start_time="2026-04-20 10:00", end_time="2026-04-20 12:00")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "#42" in msg
+    assert "lab a" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_add_slot_db_error(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    with patch("Rooms.rooms.db.execute", new=AsyncMock(side_effect=Exception("DB down"))):
+        await cog.add_slot.callback(cog, interaction, room_name="Lab A", start_time="2026-04-20 10:00", end_time="2026-04-20 12:00")
+    msg = interaction.followup.send.call_args[0][0]
+    assert "error" in msg.lower()

--- a/Tests/Rooms/test_rooms.py
+++ b/Tests/Rooms/test_rooms.py
@@ -147,3 +147,56 @@ async def test_add_slot_db_error(cog):
         await cog.add_slot.callback(cog, interaction, room_name="Lab A", start_time="2026-04-20 10:00", end_time="2026-04-20 12:00")
     msg = interaction.followup.send.call_args[0][0]
     assert "error" in msg.lower()
+
+
+# --- remove_slot ---
+
+@pytest.mark.asyncio
+async def test_remove_slot_not_found(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    with patch("Rooms.rooms.db.execute", new=AsyncMock(return_value=[])):
+        await cog.remove_slot.callback(cog, interaction, slot_id=99)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "not found" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_remove_slot_success(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    with patch("Rooms.rooms.db.execute", new=AsyncMock(side_effect=[[{"slot_id": 5}], None])):
+        await cog.remove_slot.callback(cog, interaction, slot_id=5)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "removed" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_remove_slot_db_error(cog):
+    interaction = make_interaction()
+    _pass_admin_guard(cog, interaction)
+    with patch("Rooms.rooms.db.execute", new=AsyncMock(side_effect=Exception("DB down"))):
+        await cog.remove_slot.callback(cog, interaction, slot_id=5)
+    msg = interaction.followup.send.call_args[0][0]
+    assert "error" in msg.lower()
+
+
+# --- autocomplete ---
+
+@pytest.mark.asyncio
+async def test_room_name_autocomplete_returns_choices(cog):
+    interaction = MagicMock()
+    fake_records = [{"room_name": "Lab A"}, {"room_name": "Lab B"}]
+    with patch("Rooms.rooms.db.execute", new=AsyncMock(return_value=fake_records)):
+        choices = await cog.room_name_autocomplete(interaction, "lab")
+    assert len(choices) == 2
+    assert choices[0].name == "Lab A"
+    assert choices[1].name == "Lab B"
+
+
+@pytest.mark.asyncio
+async def test_room_name_autocomplete_empty(cog):
+    interaction = MagicMock()
+    with patch("Rooms.rooms.db.execute", new=AsyncMock(return_value=[])):
+        choices = await cog.room_name_autocomplete(interaction, "zzz")
+    assert choices == []

--- a/init.sql
+++ b/init.sql
@@ -35,3 +35,23 @@ CREATE TABLE dues (
     substitues int,
     non_player int
 );
+
+CREATE TABLE rooms (
+    room_id     SERIAL PRIMARY KEY,
+    room_name   VARCHAR(100) UNIQUE NOT NULL,
+    description VARCHAR(255)
+);
+
+CREATE TABLE room_slots (
+    slot_id    SERIAL PRIMARY KEY,
+    room_id    INT REFERENCES rooms(room_id) ON DELETE CASCADE,
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time   TIMESTAMPTZ NOT NULL,
+    CHECK (end_time > start_time)
+);
+
+CREATE TABLE room_reservations (
+    reservation_id SERIAL PRIMARY KEY,
+    slot_id        INT UNIQUE REFERENCES room_slots(slot_id) ON DELETE CASCADE,
+    team_id        INT REFERENCES teams(team_id) ON DELETE CASCADE
+);


### PR DESCRIPTION
Changes

  init.sql — 3 new tables appended: rooms, room_slots, room_reservations

  Bot/Admin/set_captain.py — new file
  - /set_captain <team_nick> <member> — admin-only, updates captain for an existing active team, autocompletes team
   names

  Bot/Rooms/rooms.py — new file (admin commands)
  - /room add_room <name> [description]
  - /room add_slot <room_name> <start_time> <end_time> — format YYYY-MM-DD HH:MM, with autocomplete on room name
  - /room remove_slot <slot_id> — cascades to delete any reservation on that slot

  Bot/Rooms/reservations.py — new file
  - /reserve <slot_id> — captain-only, books slot for their team; rejects if already reserved
  - /cancel_reservation <slot_id> — captain-only, only cancels their own team's reservation
  - /list_rooms [room_name] — public, shows all unreserved slots in a table

  Bot/main.py — registered Admin.set_captain, Rooms.rooms, Rooms.reservations
  
  description generated by claude :)