### PR TITLE
Reintegrate verify

### DIFF
--- a/Bot/SetUp/backfill.py
+++ b/Bot/SetUp/backfill.py
@@ -2,6 +2,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 from utils.db import db
+from Admin.admin import Admin
 
 async def add_user(user_id: int, years_remaining: int = None):
     """
@@ -99,6 +100,16 @@ class Backfill(commands.Cog):
 
     @app_commands.command(name="backfill", description="Manually backfill the database with existing members.")
     async def backfill(self, interaction: discord.Interaction):
+        
+        admin_cog = self.bot.get_cog("Admin")
+        if (
+            not isinstance(admin_cog, Admin)
+            or not await admin_cog.is_admin(interaction.user)
+        ):
+            await interaction.response.send_message(
+                "You do not have permission to use this command.", ephemeral=True
+            )
+            return
         
         await interaction.response.defer(ephemeral=True)
 

--- a/Bot/SetUp/setup.py
+++ b/Bot/SetUp/setup.py
@@ -12,6 +12,7 @@ async def _create_initial_engineer_channel(guild: discord.Guild):
     engineer_channel = None
     if settings_records and settings_records[0]['engineer_channel_id']:
         engineer_channel = guild.get_channel(settings_records[0]['engineer_channel_id'])
+        await engineer_channel.edit(name = 'engineer')
     
     if not engineer_channel:
         engineer_channel = discord.utils.get(guild.text_channels, name='engineer')
@@ -79,10 +80,37 @@ async def _update_engineer_channel_perms(engineer_channel: discord.TextChannel, 
     await engineer_channel.send("Channel permissions have been updated for leadership roles.")
 
 async def _create_verify_channel(guild: discord.Guild, engineer_channel: discord.TextChannel):
-    #Creates the public verify channel.
-    verify_channel = await guild.create_text_channel('verify')
+    """Creates or finds the verfiy channel."""
+    settings_records = await db.execute("SELECT verify_channel_id FROM server_settings WHERE guild_id = $1", guild.id)
+    verify_channel = None
+
+    # Check if verify channel exists, if not create it
+    if settings_records and settings_records[0]['verify_channel_id']:
+        verify_channel = guild.get_channel(settings_records[0]['verify_channel_id'])
+        await verify_channel.edit(name = 'verify')
+
+    
+    # Check the guild channels directly
+    if not verify_channel:
+        verify_channel = discord.utils.get(guild.text_channels, name='verify')
+
+    overwrites = {
+        guild.default_role: discord.PermissionOverwrite(send_messages=False),
+        guild.me: discord.PermissionOverwrite(read_messages=True, send_messages=True)
+    }
+
+    if verify_channel:
+        #Clear the channel if it already exists to ensure a clean slate for verification
+        async for message in verify_channel.history(limit=None):
+            await message.delete()
+            
+        await verify_channel.edit(overwrites=overwrites)
+        await engineer_channel.send("Found existing #verify channel. Using for verification.")
+    else:
+        verify_channel = await guild.create_text_channel('verify', overwrites=overwrites)
+        await engineer_channel.send("Created #verify channel.")
+
     await db.execute("UPDATE server_settings SET verify_channel_id = $1 WHERE guild_id = $2", verify_channel.id, guild.id)
-    await engineer_channel.send("Created #verify channel.")
 
 async def setup_guild(guild: discord.Guild):
     """

--- a/Bot/SetUp/setup.py
+++ b/Bot/SetUp/setup.py
@@ -1,5 +1,6 @@
 import discord
 from utils.db import db
+from utils.verification import post_verification_message
 
 async def _init_guild_db(guild: discord.Guild):
     """Initializes the guild in the database."""
@@ -77,6 +78,12 @@ async def _update_engineer_channel_perms(engineer_channel: discord.TextChannel, 
     await engineer_channel.edit(overwrites=overwrites)
     await engineer_channel.send("Channel permissions have been updated for leadership roles.")
 
+async def _create_verify_channel(guild: discord.Guild, engineer_channel: discord.TextChannel):
+    #Creates the public verify channel.
+    verify_channel = await guild.create_text_channel('verify')
+    await db.execute("UPDATE server_settings SET verify_channel_id = $1 WHERE guild_id = $2", verify_channel.id, guild.id)
+    await engineer_channel.send("Created #verify channel.")
+
 async def setup_guild(guild: discord.Guild):
     """
     Sets up the server when the bot joins by calling modular setup functions.
@@ -87,5 +94,11 @@ async def setup_guild(guild: discord.Guild):
     
     role_objects = await _setup_roles(guild, engineer_channel)
     await _update_engineer_channel_perms(engineer_channel, role_objects)
+    
+    await _create_verify_channel(guild, engineer_channel)
+    await engineer_channel.send("Initial role and channel setup is complete. Run the `/backfill` command to populate the database with existing members. Please ensure that the bot is above the roles you want to backfill.")
+
+    await post_verification_message(guild)
+    await engineer_channel.send("Posted initial verification message.")
     
     await engineer_channel.send("Server setup complete.")

--- a/Bot/SetUp/setup.py
+++ b/Bot/SetUp/setup.py
@@ -65,7 +65,6 @@ async def _setup_roles(guild: discord.Guild, log_channel: discord.TextChannel):
 
 async def _update_engineer_channel_perms(engineer_channel: discord.TextChannel, role_objects: dict):
     """Updates the engineer channel with permissions for leadership roles."""
-    guild = engineer_channel.guild
     co_president_role = role_objects.get('Co-President')
     representative_role = role_objects.get('Representative')
 
@@ -111,6 +110,22 @@ async def _create_verify_channel(guild: discord.Guild, engineer_channel: discord
         await engineer_channel.send("Created #verify channel.")
 
     await db.execute("UPDATE server_settings SET verify_channel_id = $1 WHERE guild_id = $2", verify_channel.id, guild.id)
+    return verify_channel
+
+async def _update_verify_channel_perms(verify_channel: discord.TextChannel, role_objects: dict):
+    """Updates the verify channel with permissions for leadership roles."""
+    co_president_role = role_objects.get('Co-President')
+    representative_role = role_objects.get('Representative')
+
+    overwrites = verify_channel.overwrites
+    
+    if co_president_role:
+        overwrites[co_president_role] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
+    if representative_role:
+        overwrites[representative_role] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
+    
+    await verify_channel.edit(overwrites=overwrites)
+    await verify_channel.send("Channel permissions have been updated for leadership roles.")
 
 async def setup_guild(guild: discord.Guild):
     """
@@ -123,7 +138,9 @@ async def setup_guild(guild: discord.Guild):
     role_objects = await _setup_roles(guild, engineer_channel)
     await _update_engineer_channel_perms(engineer_channel, role_objects)
     
-    await _create_verify_channel(guild, engineer_channel)
+    verify_channel = await _create_verify_channel(guild, engineer_channel)
+    await _update_verify_channel_perms(verify_channel, role_objects)
+
     await engineer_channel.send("Initial role and channel setup is complete. Run the `/backfill` command to populate the database with existing members. Please ensure that the bot is above the roles you want to backfill.")
 
     await post_verification_message(guild)

--- a/Bot/SetUp/setup.py
+++ b/Bot/SetUp/setup.py
@@ -12,7 +12,8 @@ async def _create_initial_engineer_channel(guild: discord.Guild):
     engineer_channel = None
     if settings_records and settings_records[0]['engineer_channel_id']:
         engineer_channel = guild.get_channel(settings_records[0]['engineer_channel_id'])
-        await engineer_channel.edit(name = 'engineer')
+        if engineer_channel:
+            await engineer_channel.edit(name='engineer')
     
     if not engineer_channel:
         engineer_channel = discord.utils.get(guild.text_channels, name='engineer')
@@ -86,7 +87,8 @@ async def _create_verify_channel(guild: discord.Guild, engineer_channel: discord
     # Check if verify channel exists, if not create it
     if settings_records and settings_records[0]['verify_channel_id']:
         verify_channel = guild.get_channel(settings_records[0]['verify_channel_id'])
-        await verify_channel.edit(name = 'verify')
+        if verify_channel:
+            await verify_channel.edit(name='verify')
 
     
     # Check the guild channels directly

--- a/Bot/main.py
+++ b/Bot/main.py
@@ -5,6 +5,7 @@ from discord import app_commands
 from discord.ext import commands
 from utils.db import db
 from SetUp.setup import setup_guild
+from utils.email import email_sender
 from utils.verification import refresh_verification_message
 
 TOKEN = os.getenv("DISCORD_TOKEN")
@@ -19,6 +20,7 @@ class MyClient(commands.Bot):
 
     async def setup_hook(self):
         await db.connect()
+        await email_sender.start()
 
         # Load extensions first so their commands are registered
         await self.load_extension("Teams.create_team")

--- a/Bot/main.py
+++ b/Bot/main.py
@@ -5,6 +5,7 @@ from discord import app_commands
 from discord.ext import commands
 from utils.db import db
 from SetUp.setup import setup_guild
+from utils.verification import refresh_verification_message
 
 TOKEN = os.getenv("DISCORD_TOKEN")
 
@@ -78,6 +79,8 @@ class MyClient(commands.Bot):
                     print(f"An error occurred during setup: {e}")
                 continue
             
+            # Refresh the verification message for the guild
+            await refresh_verification_message(guild)
         #Sync the commands for each guild 
         await self.tree.sync()     
         print("Command tree synced for all guilds.")

--- a/Bot/main.py
+++ b/Bot/main.py
@@ -49,17 +49,34 @@ class MyClient(commands.Bot):
             print(f'Connected to target guild: {guild.name} (ID: {guild.id})')
             settings_records = await db.execute("SELECT * FROM server_settings WHERE guild_id = $1", guild.id)
             
-            settings = settings_records[0] 
-            engineer_channel = guild.get_channel(settings.get('engineer_channel_id'))
-            verify_channel = guild.get_channel(settings.get('verify_channel_id'))
-
-            #Check if server settings exist for this guild, if not run setup
-            if (not settings_records) or (not engineer_channel) or (not verify_channel):
+            # Check if server settings exist for this guild, if not run setup
+            if not settings_records:
                 print ("Server settings not found. Setting up server.")
                 try:
                     await setup_guild(guild=guild)
                 except Exception as e:
                     print(f"An error occurred during setup: {e}")
+                continue
+
+            # The server has a record in the database
+            settings = settings_records[0]
+            engineer_channel = guild.get_channel(settings.get('engineer_channel_id'))
+            verify_channel = guild.get_channel(settings.get('verify_channel_id'))
+
+            # Check if channels exist for this guild, if not run setup
+            if (not engineer_channel or not settings_records[0]['engineer_channel_id'] or
+                not verify_channel or not settings_records[0]['verify_channel_id']):
+
+                if not engineer_channel or not settings_records[0]['engineer_channel_id']:
+                    print("Engineer channel not found. Running setup.")
+                elif not verify_channel or not settings_records[0]['verify_channel_id']:
+                    print("Verify channel not found. Running setup.")       
+
+                try:
+                    await setup_guild(guild=guild)
+                except Exception as e:
+                    print(f"An error occurred during setup: {e}")
+                continue
             
         #Sync the commands for each guild 
         await self.tree.sync()     

--- a/Bot/main.py
+++ b/Bot/main.py
@@ -48,9 +48,13 @@ class MyClient(commands.Bot):
         for guild in self.guilds:
             print(f'Connected to target guild: {guild.name} (ID: {guild.id})')
             settings_records = await db.execute("SELECT * FROM server_settings WHERE guild_id = $1", guild.id)
+            
+            settings = settings_records[0] 
+            engineer_channel = guild.get_channel(settings.get('engineer_channel_id'))
+            verify_channel = guild.get_channel(settings.get('verify_channel_id'))
 
             #Check if server settings exist for this guild, if not run setup
-            if not settings_records:
+            if (not settings_records) or (not engineer_channel) or (not verify_channel):
                 print ("Server settings not found. Setting up server.")
                 try:
                     await setup_guild(guild=guild)

--- a/Bot/utils/email.py
+++ b/Bot/utils/email.py
@@ -1,0 +1,69 @@
+import smtplib
+import ssl
+import os
+import asyncio
+from email.message import EmailMessage
+
+class EmailSender:
+    def __init__(self):
+        self.limit = 495
+        self.counter = self.limit
+        self.smtp_server = "smtp.gmail.com"
+        self.port = 465  # For SSL
+        self.sender_email = os.getenv("GMAIL_ADDRESS")
+        self.password = os.getenv("GMAIL_APP_PASSWORD")
+        self.lock = asyncio.Lock()
+        self._task = None
+
+    async def start(self):
+        """Starts the background task to reset the counter daily."""
+        if self._task is None:
+            self._task = asyncio.create_task(self._reset_counter_daily())
+
+    async def _reset_counter_daily(self):
+        while True:
+            await asyncio.sleep(86400)  # 24 hours
+            async with self.lock:
+                self.counter = self.limit
+            print("Email counter has been reset.")
+
+    async def send_email(self, receiver_email, subject, body):
+        async with self.lock:
+            if self.counter <= 0:
+                return False, "Daily email limit reached. Please try again in 24 hours."
+            
+            # New detailed check for environment variables
+            missing_vars = []
+            if not self.sender_email:
+                missing_vars.append("GMAIL_ADDRESS")
+            if not self.password:
+                missing_vars.append("GMAIL_APP_PASSWORD")
+
+            if missing_vars:
+                error_message = f"Email service is not configured. Missing environment variables: {', '.join(missing_vars)}."
+                print(f"ERROR: {error_message}") # Also print to console for debugging
+                return False, error_message
+
+            msg = EmailMessage()
+            msg.set_content(body)
+            msg['Subject'] = subject
+            msg['From'] = self.sender_email
+            msg['To'] = receiver_email
+
+            try:
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(None, self._send_smtp, msg)
+                self.counter -= 1
+                print(f"Email sent to {receiver_email}. Remaining emails: {self.counter}")
+                return True, "Email sent successfully."
+            except Exception as e:
+                print(f"Error sending email: {e}")
+                return False, "Failed to send verification email."
+    
+    def _send_smtp(self, msg):
+        context = ssl.create_default_context()
+        with smtplib.SMTP_SSL(self.smtp_server, self.port, context=context) as server:
+            server.login(self.sender_email, self.password)
+            server.send_message(msg)
+
+email_sender = EmailSender()

--- a/Bot/utils/user_init.py
+++ b/Bot/utils/user_init.py
@@ -1,0 +1,20 @@
+from .db import db
+
+async def add_user(user_id: int, years_remaining: int = None):
+    """
+    Adds or updates a user in the database.
+
+    Args:
+        user_id (int): The Discord ID of the user.
+        years_remaining (int, optional): The number of years remaining for the user. Defaults to None.
+    """
+    await db.execute(
+        """
+        INSERT INTO users (discord_id, years_remaining)
+        VALUES ($1, $2)
+        ON CONFLICT (discord_id) DO UPDATE SET
+        years_remaining = EXCLUDED.years_remaining;
+        """,
+        user_id,
+        years_remaining
+    )

--- a/Bot/utils/verification.py
+++ b/Bot/utils/verification.py
@@ -1,0 +1,102 @@
+import discord
+from discord import app_commands
+from utils.db import db
+from verification_utils.student import start_student_verification
+from verification_utils.alumni import start_alumni_verification
+from verification_utils.friend import start_friend_verification
+from verification_utils.general import start_general_verification
+
+# This set will act as a lock to prevent users from starting multiple verification processes at once.
+VERIFYING_USERS = set()
+
+class VerificationView(discord.ui.View):
+    def __init__(self):
+        super().__init__(timeout=None)
+
+    async def on_error(self, interaction: discord.Interaction, error: Exception, item: discord.ui.Item):
+        if isinstance(error, app_commands.CommandOnCooldown):
+            # Convert remaining seconds into a user-friendly format
+            minutes, seconds = divmod(int(error.retry_after), 60)
+            await interaction.response.send_message(
+                f"This button is on cooldown. Please try again in {minutes}m {seconds}s.",
+                ephemeral=True
+            )
+        else:
+            # Handle other errors if necessary
+            await interaction.response.send_message("An unexpected error occurred.", ephemeral=True)
+            print(error)
+
+    async def _handle_verification(self, interaction: discord.Interaction, verification_function):
+        """A wrapper to handle the user verification lock."""
+        if interaction.user.id in VERIFYING_USERS:
+            await interaction.response.send_message(
+                "You already have a verification process active. Please complete or cancel it in your DMs.",
+                ephemeral=True
+            )
+            return
+        
+        VERIFYING_USERS.add(interaction.user.id)
+        try:
+            await verification_function(interaction)
+        finally:
+            # Ensure the user is always removed from the set when the process ends.
+            if interaction.user.id in VERIFYING_USERS:
+                VERIFYING_USERS.remove(interaction.user.id)
+
+    @discord.ui.button(label="Student", style=discord.ButtonStyle.primary, custom_id="student_verify")
+    @app_commands.checks.cooldown(1, 600.0, key=lambda i: i.user.id)
+    async def student_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self._handle_verification(interaction, start_student_verification)
+
+    @discord.ui.button(label="Alumni", style=discord.ButtonStyle.green, custom_id="alumni_verify")
+    @app_commands.checks.cooldown(1, 600.0, key=lambda i: i.user.id)
+    async def alumni_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self._handle_verification(interaction, start_alumni_verification)
+
+    @discord.ui.button(label="Friend", style=discord.ButtonStyle.secondary, custom_id="friend_verify")
+    @app_commands.checks.cooldown(1, 600.0, key=lambda i: i.user.id)
+    async def friend_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self._handle_verification(interaction, start_friend_verification)
+
+    @discord.ui.button(label="General Verification", style=discord.ButtonStyle.secondary, custom_id="general_verify")
+    @app_commands.checks.cooldown(1, 600.0, key=lambda i: i.user.id)
+    async def verified_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self._handle_verification(interaction, start_general_verification)
+
+async def _send_verification_embed(channel: discord.TextChannel):
+    """Sends the verification embed and view to a given channel."""
+    embed = discord.Embed(
+        title="Verification",
+        description=(
+            "Please select your status below to begin verification:\n\n"
+            "🎓 **Student** - Current RPI student\n"
+            "🎊 **Alumni** - Former RPI student\n"
+            "👥 **Friend** - Friend of an existing member\n"
+            "🔍 **General Verification** -  Any other reason"
+        ),
+        color=discord.Color.blue()
+    )
+    await channel.send(embed=embed, view=VerificationView())
+
+async def post_verification_message(guild: discord.Guild):
+    """Posts the verification message in the guild's verification channel."""
+    settings = await db.execute("SELECT verify_channel_id FROM server_settings WHERE guild_id = $1", guild.id)
+    if not settings or not settings[0]['verify_channel_id']:
+        return
+
+    channel = guild.get_channel(settings[0]['verify_channel_id'])
+    if channel:
+        await _send_verification_embed(channel)
+
+async def refresh_verification_message(guild: discord.Guild):
+    """Clears old verification messages and posts a new one."""
+    settings = await db.execute("SELECT verify_channel_id FROM server_settings WHERE guild_id = $1", guild.id)
+    if not settings or not settings[0]['verify_channel_id']:
+        return
+
+    channel = guild.get_channel(settings[0]['verify_channel_id'])
+    if channel:
+        async for message in channel.history(limit=100):
+            if message.author == guild.me:
+                await message.delete()
+        await _send_verification_embed(channel)

--- a/Bot/verification_utils/__init__.py
+++ b/Bot/verification_utils/__init__.py
@@ -1,0 +1,1 @@
+# This file intentionally left blank to mark this directory as a Python package.

--- a/Bot/verification_utils/__init__.py
+++ b/Bot/verification_utils/__init__.py
@@ -1,1 +1,0 @@
-# This file intentionally left blank to mark this directory as a Python package.

--- a/Bot/verification_utils/alumni.py
+++ b/Bot/verification_utils/alumni.py
@@ -1,0 +1,173 @@
+import discord
+import asyncio
+import os
+import re
+import random
+import string
+import tempfile
+from utils.db import db
+from utils.email import email_sender
+from utils.role_utils import handle_role_change
+
+async def scan_file_local(attachment: discord.Attachment):
+    """Scans a file using the local clamscan command-line tool."""
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+            await attachment.save(tmp_file.name)
+
+            proc = await asyncio.create_subprocess_exec(
+                'clamscan', '--no-summary', tmp_file.name,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await proc.communicate()
+
+        os.remove(tmp_file.name)
+
+        if proc.returncode == 0:
+            return True, "Clean"
+        elif proc.returncode == 1:
+            output = stdout.decode().strip()
+            virus_name = output.split(': ')[1].replace(' FOUND', '')
+            return False, f"Infected with `{virus_name}`"
+        else:
+            error_details = stderr.decode().strip()
+            print(f"Clamscan error (exit code {proc.returncode}): {error_details}")
+            return None, "An error occurred during the local file scan."
+
+    except Exception as e:
+        print(f"Clamscan execution error: {e}")
+        return None, "An unexpected error occurred while scanning the file."
+
+
+async def start_alumni_verification(interaction: discord.Interaction):
+    """Initiates the alumni verification process in DMs."""
+    try:
+        await interaction.response.send_message("I've sent you a DM to begin the alumni verification process.", ephemeral=True)
+        dm_channel = await interaction.user.create_dm()
+        
+        privacy_notice = (
+            "**Privacy Notice:** The only information that will be stored is your Discord ID. "
+            "No other personal information is stored."
+        )
+        await dm_channel.send(privacy_notice)
+
+        # Step 1: Email Verification
+        await dm_channel.send("Please enter your personal email address to continue.")
+
+        def check_email(m):
+            return m.channel == dm_channel and m.author == interaction.user
+
+        email_message = await interaction.client.wait_for('message', check=check_email, timeout=300.0)
+        email = email_message.content.strip()
+
+        if not re.match(r"[^@]+@[^@]+\.[^@]+", email):
+            await dm_channel.send("That doesn't look like a valid email address. Please start the verification process again.")
+            return
+
+        verification_code = ''.join(random.choices(string.digits, k=6))
+        
+        success, message = await email_sender.send_email(
+            email,
+            "Discord Verification Code",
+            f"Your verification code is: {verification_code}"
+        )
+
+        if not success:
+            await dm_channel.send(f"There was an error sending your verification email: {message}")
+            return
+
+        await dm_channel.send(f"A verification code has been sent to `{email}`. Please enter the 6-digit code below. You have 5 minutes.")
+
+        def check_code(m):
+            return m.channel == dm_channel and m.author == interaction.user and m.content.strip().isdigit()
+
+        code_message = await interaction.client.wait_for('message', check=check_code, timeout=300.0)
+        entered_code = code_message.content.strip()
+
+        if entered_code != verification_code:
+            await dm_channel.send("Incorrect code. Please start the verification process again.")
+            return
+
+        await dm_channel.send("Email verification successful!")
+
+        # Step 2: File Submission
+        await dm_channel.send("Please upload an image or PDF as proof of your previous enrollment (e.g., a diploma, transcript, or student ID). You have 30 minutes.")
+
+        def check_attachment(m):
+            return m.channel == dm_channel and m.author == interaction.user and m.attachments
+
+        message = await interaction.client.wait_for('message', check=check_attachment, timeout=1800.0)
+        attachment = message.attachments[0]
+
+        # --- Role Assignment Logic ---
+        settings_records = await db.execute("SELECT * FROM server_settings WHERE guild_id = $1", interaction.guild.id)
+        if not settings_records:
+            await dm_channel.send("Server settings are not configured. Please contact an administrator.")
+            return
+
+        settings = settings_records[0]
+        verified_role = interaction.guild.get_role(settings.get('verified_id'))
+        if not verified_role:
+            await dm_channel.send("The Verified role is not configured. Please contact an administrator.")
+            return
+
+        all_status_roles = {
+            'Student': interaction.guild.get_role(settings.get('student_id')),
+            'Alumni': interaction.guild.get_role(settings.get('alumni_id')),
+            'Friend': interaction.guild.get_role(settings.get('friend_id')),
+            'Verified': verified_role,
+        }
+        
+        await handle_role_change(interaction.guild, interaction.user.id, verified_role, all_status_roles)
+        await dm_channel.send(f"Thank you. Your previous status roles have been removed, and you've been granted the `{verified_role.name}` role while we review your submission.")
+
+        engineer_channel_id = settings.get('engineer_channel_id')
+        if not engineer_channel_id:
+            await dm_channel.send("Could not find the staff channel to forward your submission. Please contact an administrator.")
+            return
+
+        engineer_channel = interaction.guild.get_channel(engineer_channel_id)
+        if not engineer_channel:
+             await dm_channel.send("Could not find the staff channel to forward your submission. Please contact an administrator.")
+             return
+
+        await engineer_channel.send(f"New alumni verification submission from {interaction.user.mention} (`{interaction.user.id}`).\nScanning file locally with ClamAV...")
+        
+        is_clean, result_message = await scan_file_local(attachment)
+        
+        if is_clean is None:
+             await engineer_channel.send(f"**File Scan Error:** {result_message}")
+             return
+
+        embed_color = discord.Color.green() if is_clean else discord.Color.red()
+        scan_status = "Clean" if is_clean else "Infected"
+
+        embed = discord.Embed(
+            title="Alumni Verification Submission",
+            description=f"Scanned `{attachment.filename}` submitted by {interaction.user.mention}.",
+            color=embed_color
+        )
+        embed.add_field(name="Local Scan Result", value=f"**Status:** {scan_status}\n**Details:** {result_message}", inline=False)
+        
+        file_for_forward = await attachment.to_file()
+        await engineer_channel.send(embed=embed, file=file_for_forward)
+        
+        if not is_clean:
+            await engineer_channel.send(f"**⚠️ WARNING:** The submitted file is flagged as malicious. **Do not open it.**")
+
+        await engineer_channel.send(f"Admins: Please review the submission. If it is valid, grant the Alumni role to {interaction.user.mention}. If not, remove the Verified role.")
+
+    except asyncio.TimeoutError:
+        await dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+    except discord.errors.Forbidden:
+        error_message = ("The bot encountered a permissions error. This could be because it cannot create DMs, or because its role "
+                         "is not high enough in the server's role hierarchy to assign the 'Verified' role. Please check your "
+                         "privacy settings and ask an administrator to check the bot's role position.")
+        try:
+            await dm_channel.send(error_message)
+        except (discord.errors.Forbidden, NameError):
+            await interaction.followup.send("I couldn't send you a DM to start the process. Please check your privacy settings and allow DMs from server members.", ephemeral=True)
+    except Exception as e:
+        print(f"Error in alumni verification: {e}")
+        await dm_channel.send("An unexpected error occurred. Please contact an administrator.")

--- a/Bot/verification_utils/alumni.py
+++ b/Bot/verification_utils/alumni.py
@@ -9,6 +9,13 @@ from utils.db import db
 from utils.email import email_sender
 from utils.role_utils import handle_role_change
 
+
+async def _send_ephemeral_error(interaction: discord.Interaction, message: str):
+    if interaction.response.is_done():
+        await interaction.followup.send(message, ephemeral=True)
+    else:
+        await interaction.response.send_message(message, ephemeral=True)
+
 async def scan_file_local(attachment: discord.Attachment):
     """Scans a file using the local clamscan command-line tool."""
     try:
@@ -42,6 +49,7 @@ async def scan_file_local(attachment: discord.Attachment):
 
 async def start_alumni_verification(interaction: discord.Interaction):
     """Initiates the alumni verification process in DMs."""
+    dm_channel = None
     try:
         await interaction.response.send_message("I've sent you a DM to begin the alumni verification process.", ephemeral=True)
         dm_channel = await interaction.user.create_dm()
@@ -159,15 +167,30 @@ async def start_alumni_verification(interaction: discord.Interaction):
         await engineer_channel.send(f"Admins: Please review the submission. If it is valid, grant the Alumni role to {interaction.user.mention}. If not, remove the Verified role.")
 
     except asyncio.TimeoutError:
-        await dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+        if dm_channel:
+            await dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+        else:
+            await _send_ephemeral_error(
+                interaction,
+                "The verification process timed out before a DM channel was established. Please try again.",
+            )
     except discord.errors.Forbidden:
         error_message = ("The bot encountered a permissions error. This could be because it cannot create DMs, or because its role "
                          "is not high enough in the server's role hierarchy to assign the 'Verified' role. Please check your "
                          "privacy settings and ask an administrator to check the bot's role position.")
-        try:
+        if dm_channel:
             await dm_channel.send(error_message)
-        except (discord.errors.Forbidden, NameError):
-            await interaction.followup.send("I couldn't send you a DM to start the process. Please check your privacy settings and allow DMs from server members.", ephemeral=True)
+        else:
+            await _send_ephemeral_error(
+                interaction,
+                "I couldn't send you a DM to start the process. Please check your privacy settings and allow DMs from server members.",
+            )
     except Exception as e:
         print(f"Error in alumni verification: {e}")
-        await dm_channel.send("An unexpected error occurred. Please contact an administrator.")
+        if dm_channel:
+            await dm_channel.send("An unexpected error occurred. Please contact an administrator.")
+        else:
+            await _send_ephemeral_error(
+                interaction,
+                "An unexpected error occurred. Please contact an administrator.",
+            )

--- a/Bot/verification_utils/friend.py
+++ b/Bot/verification_utils/friend.py
@@ -1,0 +1,86 @@
+import discord
+import asyncio
+from utils.db import db
+from utils.user_init import add_user
+from .friend_confirmation_view import FriendConfirmationView
+from utils.role_utils import handle_role_change
+
+async def start_friend_verification(interaction: discord.Interaction):
+    """Initiates the friend verification process with confirmation from the friend."""
+    try:
+        user_dm_channel = await interaction.user.create_dm()
+        await interaction.response.send_message("I've sent you a DM to begin the friend verification process.", ephemeral=True)
+
+        privacy_notice = (
+            "**Privacy Notice:** The only information that will be stored is your Discord ID. "
+            "No other personal information is stored."
+        )
+        await user_dm_channel.send(privacy_notice)
+        
+        await user_dm_channel.send("Please provide the exact Discord username (e.g., `username`) of a friend who is already a verified member of this server.")
+
+        def check_username(m):
+            return m.channel == user_dm_channel and m.author == interaction.user
+
+        username_message = await interaction.client.wait_for('message', check=check_username, timeout=300.0)
+        friend_username = username_message.content.strip()
+
+        friend_member = discord.utils.get(interaction.guild.members, name=friend_username)
+
+        if not friend_member or friend_member.id == interaction.user.id:
+            await user_dm_channel.send(f"I couldn't find a valid member with that username. Please check the spelling and try again.")
+            return
+
+        settings = await db.execute("SELECT student_id, verified_id, alumni_id, friend_id FROM server_settings WHERE guild_id = $1", interaction.guild.id)
+        if not settings:
+            await user_dm_channel.send("Role info is not configured. Please contact an admin.")
+            return
+
+        valid_role_ids = {settings[0][key] for key in ['student_id', 'verified_id', 'alumni_id', 'friend_id'] if settings[0].get(key)}
+        if not any(role.id in valid_role_ids for role in friend_member.roles):
+            await user_dm_channel.send(f"`{friend_username}` is not a verified member. Please provide the username of a verified member.")
+            return
+
+        await user_dm_channel.send(f"I have found `{friend_username}`. I will now ask for their confirmation. They have 30 minutes to respond.")
+
+        try:
+            friend_dm_channel = await friend_member.create_dm()
+            confirmation_view = FriendConfirmationView(interaction.user, friend_member)
+            await friend_dm_channel.send(
+                f"Hello! {interaction.user.mention} has requested to be verified as your friend in the `{interaction.guild.name}` server. "
+                "Do you know this person?",
+                view=confirmation_view
+            )
+            
+            await confirmation_view.wait() # Wait for the friend to click a button or for the view to time out
+
+            if confirmation_view.result is True:
+                friend_role = interaction.guild.get_role(settings[0].get('friend_id'))
+                if friend_role:
+                    all_status_roles = {
+                        'Student': interaction.guild.get_role(settings[0].get('student_id')),
+                        'Alumni': interaction.guild.get_role(settings[0].get('alumni_id')),
+                        'Friend': friend_role,
+                        'Verified': interaction.guild.get_role(settings[0].get('verified_id')),
+                    }
+                    await handle_role_change(interaction.guild, interaction.user.id, friend_role, all_status_roles)
+                    await add_user(interaction.user.id, -1)
+                    await user_dm_channel.send(f"`{friend_username}` has confirmed your request! Your previous status roles have been removed and you have been granted the {friend_role.name} role.")
+                else:
+                    await user_dm_channel.send("Your friend confirmed, but the 'Friend' role is not configured on this server.")
+            elif confirmation_view.result is False:
+                await user_dm_channel.send(f"Your verification request was denied by `{friend_username}`.")
+            else: # Timeout
+                await user_dm_channel.send(f"`{friend_username}` did not respond in time. Your verification request has expired.")
+
+        except discord.Forbidden:
+            await user_dm_channel.send(f"I could not send a DM to `{friend_username}`. They may have DMs disabled. Please ask them to enable DMs and try again.")
+            return
+
+    except asyncio.TimeoutError:
+        await user_dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+    except discord.errors.Forbidden:
+        await interaction.followup.send("I couldn't send you a DM to start the process. Please check your privacy settings.", ephemeral=True)
+    except Exception as e:
+        print(f"Error in friend verification: {e}")
+        await user_dm_channel.send("An unexpected error occurred. Please contact an administrator.")

--- a/Bot/verification_utils/friend.py
+++ b/Bot/verification_utils/friend.py
@@ -5,8 +5,16 @@ from utils.user_init import add_user
 from .friend_confirmation_view import FriendConfirmationView
 from utils.role_utils import handle_role_change
 
+
+async def _send_ephemeral_error(interaction: discord.Interaction, message: str):
+    if interaction.response.is_done():
+        await interaction.followup.send(message, ephemeral=True)
+    else:
+        await interaction.response.send_message(message, ephemeral=True)
+
 async def start_friend_verification(interaction: discord.Interaction):
     """Initiates the friend verification process with confirmation from the friend."""
+    user_dm_channel = None
     try:
         user_dm_channel = await interaction.user.create_dm()
         await interaction.response.send_message("I've sent you a DM to begin the friend verification process.", ephemeral=True)
@@ -78,9 +86,24 @@ async def start_friend_verification(interaction: discord.Interaction):
             return
 
     except asyncio.TimeoutError:
-        await user_dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+        if user_dm_channel:
+            await user_dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+        else:
+            await _send_ephemeral_error(
+                interaction,
+                "The verification process timed out before a DM channel was established. Please try again.",
+            )
     except discord.errors.Forbidden:
-        await interaction.followup.send("I couldn't send you a DM to start the process. Please check your privacy settings.", ephemeral=True)
+        await _send_ephemeral_error(
+            interaction,
+            "I couldn't send you a DM to start the process. Please check your privacy settings.",
+        )
     except Exception as e:
         print(f"Error in friend verification: {e}")
-        await user_dm_channel.send("An unexpected error occurred. Please contact an administrator.")
+        if user_dm_channel:
+            await user_dm_channel.send("An unexpected error occurred. Please contact an administrator.")
+        else:
+            await _send_ephemeral_error(
+                interaction,
+                "An unexpected error occurred. Please contact an administrator.",
+            )

--- a/Bot/verification_utils/friend_confirmation_view.py
+++ b/Bot/verification_utils/friend_confirmation_view.py
@@ -1,0 +1,39 @@
+import discord
+
+class FriendConfirmationView(discord.ui.View):
+    def __init__(self, author: discord.Member, friend: discord.Member):
+        super().__init__(timeout=1800.0)  # 30-minute timeout
+        self.author = author
+        self.friend = friend
+        self.result = None
+
+    @discord.ui.button(label="Yes", style=discord.ButtonStyle.success)
+    async def yes_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if interaction.user.id != self.friend.id:
+            await interaction.response.send_message("This is not for you.", ephemeral=True)
+            return
+        
+        self.result = True
+        self.stop()
+        # Disable the buttons after a choice is made
+        for item in self.children:
+            item.disabled = True
+        await interaction.response.edit_message(content=f"You have confirmed that you know {self.author.mention}. Thank you!", view=self)
+
+    @discord.ui.button(label="No", style=discord.ButtonStyle.danger)
+    async def no_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if interaction.user.id != self.friend.id:
+            await interaction.response.send_message("This is not for you.", ephemeral=True)
+            return
+            
+        self.result = False
+        self.stop()
+        for item in self.children:
+            item.disabled = True
+        await interaction.response.edit_message(content=f"You have denied the request from {self.author.mention}. Thank you.", view=self)
+
+    async def on_timeout(self):
+        # This is called if the friend doesn't respond in time
+        self.result = False
+        # We can't edit the message here as we don't have an interaction,
+        # but the view will stop listening for events.

--- a/Bot/verification_utils/general.py
+++ b/Bot/verification_utils/general.py
@@ -8,8 +8,16 @@ from utils.email import email_sender
 from utils.user_init import add_user
 from utils.role_utils import handle_role_change
 
+
+async def _send_ephemeral_error(interaction: discord.Interaction, message: str):
+    if interaction.response.is_done():
+        await interaction.followup.send(message, ephemeral=True)
+    else:
+        await interaction.response.send_message(message, ephemeral=True)
+
 async def start_general_verification(interaction: discord.Interaction):
     """Initiates the general email verification process in DMs."""
+    dm_channel = None
     try:
         await interaction.response.send_message("I've sent you a DM to begin the general verification process.", ephemeral=True)
         dm_channel = await interaction.user.create_dm()
@@ -79,15 +87,30 @@ async def start_general_verification(interaction: discord.Interaction):
         await dm_channel.send(f"Verification successful! Your previous status roles have been removed and you have been granted the {verified_role.name} role. Welcome!")
 
     except asyncio.TimeoutError:
-        await dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+        if dm_channel:
+            await dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+        else:
+            await _send_ephemeral_error(
+                interaction,
+                "The verification process timed out before a DM channel was established. Please try again.",
+            )
     except discord.errors.Forbidden:
         error_message = ("The bot encountered a permissions error. This could be because it cannot create DMs, or because its role "
                          "is not high enough in the server's role hierarchy to assign the 'Verified' role. Please check your "
                          "privacy settings and ask an administrator to check the bot's role position.")
-        try:
+        if dm_channel:
             await dm_channel.send(error_message)
-        except (discord.errors.Forbidden, NameError):
-            await interaction.followup.send("I couldn't send you a DM to start the process. Please check your privacy settings and allow DMs from server members.", ephemeral=True)
+        else:
+            await _send_ephemeral_error(
+                interaction,
+                "I couldn't send you a DM to start the process. Please check your privacy settings and allow DMs from server members.",
+            )
     except Exception as e:
         print(f"Error in general verification: {e}")
-        await dm_channel.send("An unexpected error occurred. Please contact an administrator.")
+        if dm_channel:
+            await dm_channel.send("An unexpected error occurred. Please contact an administrator.")
+        else:
+            await _send_ephemeral_error(
+                interaction,
+                "An unexpected error occurred. Please contact an administrator.",
+            )

--- a/Bot/verification_utils/general.py
+++ b/Bot/verification_utils/general.py
@@ -1,0 +1,93 @@
+import discord
+import asyncio
+import re
+import random
+import string
+from utils.db import db
+from utils.email import email_sender
+from utils.user_init import add_user
+from utils.role_utils import handle_role_change
+
+async def start_general_verification(interaction: discord.Interaction):
+    """Initiates the general email verification process in DMs."""
+    try:
+        await interaction.response.send_message("I've sent you a DM to begin the general verification process.", ephemeral=True)
+        dm_channel = await interaction.user.create_dm()
+
+        privacy_notice = (
+            "**Privacy Notice:** The only information that will be stored is your Discord ID. "
+            "No other personal information is stored."
+        )
+        await dm_channel.send(privacy_notice)
+
+        await dm_channel.send("Please enter your email address.")
+
+        def check_email(m):
+            return m.channel == dm_channel and m.author == interaction.user
+
+        email_message = await interaction.client.wait_for('message', check=check_email, timeout=300.0)
+        email = email_message.content.strip()
+
+        if not re.match(r"[^@]+@[^@]+\.[^@]+", email):
+            await dm_channel.send("That doesn't look like a valid email address. Please start the verification process again.")
+            return
+
+        verification_code = ''.join(random.choices(string.digits, k=6))
+        
+        success, message = await email_sender.send_email(
+            email,
+            "Discord Verification Code",
+            f"Your verification code is: {verification_code}"
+        )
+
+        if not success:
+            await dm_channel.send(f"There was an error sending your verification email: {message}")
+            return
+
+        await dm_channel.send(f"A verification code has been sent to `{email}`. Please enter the 6-digit code below. You have 5 minutes.")
+
+        def check_code(m):
+            return m.channel == dm_channel and m.author == interaction.user and m.content.strip().isdigit()
+
+        code_message = await interaction.client.wait_for('message', check=check_code, timeout=300.0)
+        entered_code = code_message.content.strip()
+
+        if entered_code != verification_code:
+            await dm_channel.send("Incorrect code. Please start the verification process again.")
+            return
+
+        settings_records = await db.execute("SELECT * FROM server_settings WHERE guild_id = $1", interaction.guild.id)
+        if not settings_records:
+            await dm_channel.send("Server settings are not configured. Please contact an administrator.")
+            return
+
+        settings = settings_records[0]
+        verified_role = interaction.guild.get_role(settings.get('verified_id'))
+        if not verified_role:
+            await dm_channel.send("The Verified role could not be found. Please contact an administrator.")
+            return
+
+        all_status_roles = {
+            'Student': interaction.guild.get_role(settings.get('student_id')),
+            'Alumni': interaction.guild.get_role(settings.get('alumni_id')),
+            'Friend': interaction.guild.get_role(settings.get('friend_id')),
+            'Verified': verified_role,
+        }
+
+        await handle_role_change(interaction.guild, interaction.user.id, verified_role, all_status_roles)
+        await add_user(interaction.user.id, -2)
+        await dm_channel.send(f"Verification successful! Your previous status roles have been removed and you have been granted the {verified_role.name} role. Welcome!")
+
+    except asyncio.TimeoutError:
+        await dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+    except discord.errors.Forbidden:
+        error_message = ("The bot encountered a permissions error. This could be because it cannot create DMs, or because its role "
+                         "is not high enough in the server's role hierarchy to assign the 'Verified' role. Please check your "
+                         "privacy settings and ask an administrator to check the bot's role position.")
+        try:
+            await dm_channel.send(error_message)
+        except (discord.errors.Forbidden, NameError):
+            await interaction.followup.send("I couldn't send you a DM to start the process. Please check your privacy settings and allow DMs from server members.", ephemeral=True)
+    except Exception as e:
+        print(f"Error in general verification: {e}")
+        await dm_channel.send("An unexpected error occurred. Please contact an administrator.")

--- a/Bot/verification_utils/student.py
+++ b/Bot/verification_utils/student.py
@@ -8,8 +8,16 @@ from utils.email import email_sender
 from utils.user_init import add_user
 from utils.role_utils import handle_role_change
 
+
+async def _send_ephemeral_error(interaction: discord.Interaction, message: str):
+    if interaction.response.is_done():
+        await interaction.followup.send(message, ephemeral=True)
+    else:
+        await interaction.response.send_message(message, ephemeral=True)
+
 async def start_student_verification(interaction: discord.Interaction):
     """Initiates the student verification process in DMs."""
+    dm_channel = None
     try:
         await interaction.response.send_message("I've sent you a DM to begin the student verification process.", ephemeral=True)
         dm_channel = await interaction.user.create_dm()
@@ -90,17 +98,30 @@ async def start_student_verification(interaction: discord.Interaction):
         await dm_channel.send(f"You have been granted the {student_role.name} role and your previous status roles have been removed. Welcome!")
 
     except asyncio.TimeoutError:
-        await dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+        if dm_channel:
+            await dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+        else:
+            await _send_ephemeral_error(
+                interaction,
+                "The verification process timed out before a DM channel was established. Please try again.",
+            )
     except discord.errors.Forbidden:
         # This error is now smarter. It checks if a DM has already been established.
         error_message = ("The bot encountered a permissions error. This is most likely because its role is not high enough "
                          "in the server's role hierarchy to assign the 'Student' role. Please ask an administrator to move the bot's role up.")
-        try:
-            # If the DM is open, send the error there where the user is looking.
+        if dm_channel:
             await dm_channel.send(error_message)
-        except (discord.errors.Forbidden, NameError):
-            # If we couldn't even open the DM, send it as a followup.
-            await interaction.followup.send("I couldn't send you a DM to start the process. Please check your privacy settings and allow DMs from server members.", ephemeral=True)
+        else:
+            await _send_ephemeral_error(
+                interaction,
+                "I couldn't send you a DM to start the process. Please check your privacy settings and allow DMs from server members.",
+            )
     except Exception as e:
         print(f"Error in student verification: {e}")
-        await dm_channel.send("An unexpected error occurred. Please contact an administrator.")
+        if dm_channel:
+            await dm_channel.send("An unexpected error occurred. Please contact an administrator.")
+        else:
+            await _send_ephemeral_error(
+                interaction,
+                "An unexpected error occurred. Please contact an administrator.",
+            )

--- a/Bot/verification_utils/student.py
+++ b/Bot/verification_utils/student.py
@@ -1,0 +1,106 @@
+import discord
+import asyncio
+import re
+import random
+import string
+from utils.db import db
+from utils.email import email_sender
+from utils.user_init import add_user
+from utils.role_utils import handle_role_change
+
+async def start_student_verification(interaction: discord.Interaction):
+    """Initiates the student verification process in DMs."""
+    try:
+        await interaction.response.send_message("I've sent you a DM to begin the student verification process.", ephemeral=True)
+        dm_channel = await interaction.user.create_dm()
+        
+        privacy_notice = (
+            "**Privacy Notice:** The only information that will be stored is your Discord ID and, if you are a student, "
+            "the number of years you expect to remain at RPI. No other personal information is stored."
+        )
+        await dm_channel.send(privacy_notice)
+
+        await dm_channel.send("Please enter your RCSID (e.g., 'turing25').")
+
+        def check_rcsid(m):
+            return m.channel == dm_channel and m.author == interaction.user
+
+        rcsid_message = await interaction.client.wait_for('message', check=check_rcsid, timeout=300.0)
+        rcsid = rcsid_message.content.strip().lower()
+
+        if not re.match(r"^[a-z]{2,8}[0-9]{1,2}$", rcsid):
+            await dm_channel.send("That doesn't look like a valid RCSID. Please start the verification process again.")
+            return
+
+        verification_code = ''.join(random.choices(string.digits, k=6))
+        email_address = f"{rcsid}@rpi.edu"
+        
+        success, message = await email_sender.send_email(
+            email_address,
+            "RPI Discord Verification Code",
+            f"Your verification code is: {verification_code}"
+        )
+
+        if not success:
+            await dm_channel.send(f"There was an error sending your verification email: {message}")
+            return
+
+        await dm_channel.send(f"A verification code has been sent to `{email_address}`. Please enter the 6-digit code below. You have 5 minutes.")
+
+        def check_code(m):
+            return m.channel == dm_channel and m.author == interaction.user and m.content.strip().isdigit()
+
+        code_message = await interaction.client.wait_for('message', check=check_code, timeout=300.0)
+        entered_code = code_message.content.strip()
+
+        if entered_code != verification_code:
+            await dm_channel.send("Incorrect code. Please start the verification process again.")
+            return
+
+        await dm_channel.send("Verification successful! How many years do you expect to attend RPI? (Please enter a number from 1 to 8)")
+
+        def check_years(m):
+            return m.channel == dm_channel and m.author == interaction.user and m.content.strip().isdigit() and 1 <= int(m.content.strip()) <= 8
+
+        years_message = await interaction.client.wait_for('message', check=check_years, timeout=300.0)
+        years_remaining = int(years_message.content.strip())
+        
+        # --- Role Assignment Logic ---
+        settings_records = await db.execute("SELECT * FROM server_settings WHERE guild_id = $1", interaction.guild.id)
+        if not settings_records:
+            await dm_channel.send("Server settings are not configured. Please contact an administrator.")
+            return
+        
+        settings = settings_records[0]
+        student_role = interaction.guild.get_role(settings.get('student_id'))
+        if not student_role:
+            await dm_channel.send("The Student role could not be found. Please contact an administrator.")
+            return
+
+        all_status_roles = {
+            'Student': student_role,
+            'Alumni': interaction.guild.get_role(settings.get('alumni_id')),
+            'Friend': interaction.guild.get_role(settings.get('friend_id')),
+            'Verified': interaction.guild.get_role(settings.get('verified_id')),
+        }
+
+        await handle_role_change(interaction.guild, interaction.user.id, student_role, all_status_roles)
+        await add_user(interaction.user.id, years_remaining)
+
+        await dm_channel.send(f"You have been granted the {student_role.name} role and your previous status roles have been removed. Welcome!")
+
+    except asyncio.TimeoutError:
+        await dm_channel.send("You took too long to respond. The verification process has expired. Please try again.")
+    except discord.errors.Forbidden:
+        # This error is now smarter. It checks if a DM has already been established.
+        error_message = ("The bot encountered a permissions error. This is most likely because its role is not high enough "
+                         "in the server's role hierarchy to assign the 'Student' role. Please ask an administrator to move the bot's role up.")
+        try:
+            # If the DM is open, send the error there where the user is looking.
+            await dm_channel.send(error_message)
+        except (discord.errors.Forbidden, NameError):
+            # If we couldn't even open the DM, send it as a followup.
+            await interaction.followup.send("I couldn't send you a DM to start the process. Please check your privacy settings and allow DMs from server members.", ephemeral=True)
+    except Exception as e:
+        print(f"Error in student verification: {e}")
+        await dm_channel.send("An unexpected error occurred. Please contact an administrator.")

--- a/Bot/year.py
+++ b/Bot/year.py
@@ -3,6 +3,7 @@ from discord import app_commands
 from discord.ext import commands
 from utils.db import db
 from utils.role_utils import handle_role_change
+from Admin.admin import Admin
 
 class Year(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -14,6 +15,16 @@ class Year(commands.Cog):
         Admin command logic to update student years, graduate students, and clean up the database.
         """
 
+        admin_cog = self.bot.get_cog("Admin")
+        if (
+            not isinstance(admin_cog, Admin)
+            or not await admin_cog.is_admin(interaction.user)
+        ):
+            await interaction.response.send_message(
+                "You do not have permission to use this command.", ephemeral=True
+            )
+            return
+        
         await interaction.response.defer(ephemeral=True)
 
         guild = interaction.guild  

--- a/Documentation/SetUp.md
+++ b/Documentation/SetUp.md
@@ -1,0 +1,20 @@
+# Setup Module Documentation
+
+## setup.py
+Contains the methods related to creating and managing server roles and channels.
+- **_create_initial_engineer_channel**: The bot will create or use an existing channel named `engineer` to be used for database changes log.
+- **_setup_roles**: The bot will create or use existing roles like co-president, representatives, and other verified roles for the server to use.
+- **_update_engineer_channel_perms**: The bot will overwrite the `engineer` channel read and send message permissions for only leadership roles and itself.
+- **_create_verify_channel**: The bot will create or use an existing channel named `verify` to be used for starting the verification process.
+- **_update_verify_channel_perms**: The bot will overwrite the `verify` channel permissions to read-only for everyone except leadership roles.
+- **setup_guild**: Utilizes the previous functions and runs all of them to set up the guild.
+
+## backfill.py
+Contains the logic for managing and updating user data in the database.
+- **add_user**: The bot will add the user's Discord ID and years remaining into the database.
+- **_backfill_users**: The bot will search through the server's member list and record any missing members in the database. This has an optional argument to assign verified status to all undocumented members when run.
+- **backfill**: The bot command which will run `_backfill_users` and log all changes in the `engineer` channel.
+
+## year.py
+Contains the logic for managing member statuses based on years remaining.
+- **year_command_logic**: The bot will decrease years remaining of all members in the database whose value is above 0. If any member results in 0 years remaining, their status in the server becomes `alumni`.


### PR DESCRIPTION
Bot/verification_utils
Added logic for the 4 verified roles: Student, Friend, Alumni and General. Student, Alumni and General will require the user to input a valid related email for a code verification, Friend will require an already verified member to vouch for the user.

Bot/utils/verification.py
Added interactable verification embedded message which uses the 4 verified roles logic. 

Bot/utils/user_init.py
Added a method to add a user's discord id and years remaining into the db

Changes 
Modified setup.py 
Included a method for creating verify channel which will create or find an existing channel to use for verify. This channel will have read only permissions for all member except the bot and leadership roles.

Modified main.py 
On_Ready now checks server setting records, engineer channel, verify channel and their IDs for each connected server. If any is missing the setup logic is ran again.
On_Ready the verification message is deleted and posted again by the bot to avoid interaction failure between each restart.
